### PR TITLE
Pass clients actions to redux store and add test data

### DIFF
--- a/entries.json
+++ b/entries.json
@@ -1,0 +1,13 @@
+[
+  "Wildes Dreams",
+  "Blank Space",
+  "Style",
+  "Shake It Off",
+  "Love Story",
+  "Bad Blood",
+  "22",
+  "We Are Never Ever Getting Back Together",
+  "Teardrops on My Guitar",
+  "Our Song",
+  "Back to December"
+]

--- a/index.js
+++ b/index.js
@@ -3,3 +3,11 @@ import startServer from './src/server';
 
 export const store = makeStore();
 startServer(store);
+
+// load test data
+// and kick off the vote
+store.dispatch({
+  type: 'SET_ENTRIES',
+  entries: require('./entries.json')
+});
+store.dispatch({ type: 'NEXT' });

--- a/src/server.js
+++ b/src/server.js
@@ -13,5 +13,10 @@ export default function startServer(store) {
 
   io.on('connection', (socket) => {
     socket.emit('state', store.getState().toJS());
+
+    // clients emit 'action' events that we feed directly into our Redux store
+    // this a security issue with this as any connected client is allowed to dispatch
+    // any action into the Redux store
+    socket.on('action', store.dispatch.bind(store));
   });
 }


### PR DESCRIPTION
This pull request resolves #5 

This adds a listener of client actions and passes them onto the redux store

The server side application flow:
1. A client sends an action to the server
2. The server hands the action to the Redux Store.
3. The Store calls the reducer and the reducer executes the logic related to the action.
4. The Store updates its state based on the return value of the reducer.
5. The Store executes the listener function subscribed by the server.
6. The server emits a 'state' event.
7. All connected clients - including the one that initiated the original action - receive the new state.
